### PR TITLE
Allow browsers access pagination data in headers

### DIFF
--- a/src/common/helper.js
+++ b/src/common/helper.js
@@ -345,6 +345,14 @@ function setResHeaders (req, res, result) {
     }
     res.set('Link', link)
   }
+
+  // Allow browsers access pagination data in headers
+  let accessControlExposeHeaders = res.get('Access-Control-Expose-Headers') || ''
+  accessControlExposeHeaders += accessControlExposeHeaders ? ', ' : ''
+  // append new values, to not override values set by someone else
+  accessControlExposeHeaders += 'X-Page, X-Per-Page, X-Total, X-Total-Pages, X-Prev-Page, X-Next-Page'
+
+  res.set('Access-Control-Expose-Headers', accessControlExposeHeaders)
 }
 
 /**


### PR DESCRIPTION
For the pagination functionality, we set headers `X-Page, X-Per-Page, X-Total, X-Total-Pages, X-Prev-Page, X-Next-Page`, so a client app can read them to show total number of the pages.

Due to security reasons, browsers do not allow access to custom headers unless explicitly set.
To let client-side code access pagination headers we have to set `Access-Control-Expose-Headers` header, see:
- [Access-Control-Expose-Headers on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers)
- [Issue description on StackOverflow](https://stackoverflow.com/questions/40852893/accessing-custom-http-response-headers-in-angularjs/40855123)

This is done via this PR.