### PR TITLE
Allow browsers access pagination data in headers (CORS)

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,7 +22,10 @@ const app = express()
 // serve resources V5 API swagger definition
 app.use('/v5/resources/docs', swaggerUi.serve, swaggerUi.setup(resourcesAPISwaggerDoc))
 
-app.use(cors())
+app.use(cors({
+  // Allow browsers access pagination data in headers
+  exposedHeaders: ['X-Page', 'X-Per-Page', 'X-Total', 'X-Total-Pages', 'X-Prev-Page', 'X-Next-Page']
+}))
 app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: true }))
 app.set('port', config.PORT)


### PR DESCRIPTION
For the pagination functionality, we set headers `X-Page, X-Per-Page, X-Total, X-Total-Pages, X-Prev-Page, X-Next-Page`, so a client app can read them to show total number of the pages.

Due to security reasons, browsers do not allow access to custom headers unless explicitly set.
To let client-side code access pagination headers we have to set `Access-Control-Expose-Headers` header, see:
- [Access-Control-Expose-Headers on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers)
- [Issue description on StackOverflow](https://stackoverflow.com/questions/40852893/accessing-custom-http-response-headers-in-angularjs/40855123)

This is done via this PR.